### PR TITLE
Add required surefire plugin to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,14 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.1</version>
+				<configuration>
+					<useSystemClassLoader>false</useSystemClassLoader>
+				</configuration>
+			</plugin>
+			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.7.0</version>
 				<configuration>


### PR DESCRIPTION
The code was not able to run tests on my Ubuntu 18.04 system, using openjdk1.8, without adding this line.
Executing mvn test output would always crash with:
Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter