### PR TITLE
Schematransform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>edu.iris.dmc</groupId>
 	<artifactId>stationxml-seed-converter</artifactId>
-	<version>2.1.0-RC-3-SNAPSHOT</version>
+	<version>2.1.0-RC-03-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>stationxml-seed-converter</name>
@@ -184,7 +184,7 @@
 		<dependency>
 			<groupId>edu.iris.dmc</groupId>
 			<artifactId>fdsn-stationxml-model</artifactId>
-			<version>1.6.0-RC-2</version>
+			<version>1.6.0-RC-03-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
 		<dependency>
 			<groupId>edu.iris.dmc</groupId>
 			<artifactId>fdsn-stationxml-model</artifactId>
-			<version>1.6.0-RC-03-SNAPSHOT</version>
+			<version>1.6.0-RC-2</version>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>

--- a/src/main/java/edu/iris/dmc/station/Application.java
+++ b/src/main/java/edu/iris/dmc/station/Application.java
@@ -63,7 +63,7 @@ public class Application {
 	private boolean debug;
 	private boolean lab=false;
 	private boolean org=false;
-	private boolean schematransform=false;
+	private boolean schemaUpdate=false;
 
 	public static void main(String[] args) throws Exception {
 		Application application = new Application();
@@ -105,9 +105,9 @@ public class Application {
 			
 			} else if ("--large".equals(arg)) {
 				map.put("large", "true");
-			} else if ("--schema-transform".equals(arg)) {
-				map.put("schematransform", args[i]);
-				schematransform=true;
+			} else if ("--schema-update".equals(arg)) {
+				map.put("schemaupdate", args[i]);
+				schemaUpdate=true;
 			} else if ("--align-epochs".equals(arg)) {
 				map.put("align", "true");
 			} else {
@@ -162,7 +162,7 @@ public class Application {
 				if(org==true) {
 					logger.info("Originating Organization [B10:F8] is set as " + map.get("organization"));
 				}
-				if(schematransform==true) {
+				if(schemaUpdate==true) {
 					logger.info("Input file: " + source.getPath());
 					logger.info("Input file is formatted as StationXML");
 					logger.info("Output file is formatted as StationXML 1.1");
@@ -258,7 +258,7 @@ public class Application {
 		System.out.println("   --output             : output file path and name");
 		System.out.println("   --label              : specify label for use in B10");
 		System.out.println("   --organization       : specify organization for use in B10");
-		System.out.println("   --schema-transform   : transforms input stationxml from version 1.0 to version 1.1");
+		System.out.println("   --schema-update      : updates input stationxml from version 1.0 to version 1.1");
 		System.out.println("   --continue-on-error  : prints exceptions to stdout and processes next file");
 		System.out.println("===============================================================");
 		System.exit(0);

--- a/src/main/java/edu/iris/dmc/station/Application.java
+++ b/src/main/java/edu/iris/dmc/station/Application.java
@@ -46,6 +46,7 @@ import edu.iris.dmc.station.Application;
 import edu.iris.dmc.station.converter.MetadataFileFormatConverter;
 import edu.iris.dmc.station.converter.SeedToXmlFileConverter;
 import edu.iris.dmc.station.converter.XmlToSeedFileConverter;
+import edu.iris.dmc.station.converter.XmlToXmlFileConverter;
 import edu.iris.dmc.station.mapper.MetadataConverterException;
 
 public class Application {
@@ -62,6 +63,7 @@ public class Application {
 	private boolean debug;
 	private boolean lab=false;
 	private boolean org=false;
+	private boolean schematransform=false;
 
 	public static void main(String[] args) throws Exception {
 		Application application = new Application();
@@ -103,7 +105,9 @@ public class Application {
 			
 			} else if ("--large".equals(arg)) {
 				map.put("large", "true");
-			
+			} else if ("--schema-transform".equals(arg)) {
+				map.put("schematransform", args[i]);
+				schematransform=true;
 			} else if ("--align-epochs".equals(arg)) {
 				map.put("align", "true");
 			} else {
@@ -157,6 +161,14 @@ public class Application {
 				}
 				if(org==true) {
 					logger.info("Originating Organization [B10:F8] is set as " + map.get("organization"));
+				}
+				if(schematransform==true) {
+					logger.info("Input file: " + source.getPath());
+					logger.info("Input file is formatted as StationXML");
+					logger.info("Output file is formatted as StationXML 1.1");
+					converter = XmlToXmlFileConverter.getInstance();
+					extension = "xml";
+					
 				}
 			} else {
 				logger.info("Input file: " + source.getPath());
@@ -246,6 +258,7 @@ public class Application {
 		System.out.println("   --output             : output file path and name");
 		System.out.println("   --label              : specify label for use in B10");
 		System.out.println("   --organization       : specify organization for use in B10");
+		System.out.println("   --schema-transform   : transforms input stationxml from version 1.0 to version 1.1");
 		System.out.println("   --continue-on-error  : prints exceptions to stdout and processes next file");
 		System.out.println("===============================================================");
 		System.exit(0);

--- a/src/main/java/edu/iris/dmc/station/converter/SeedToXmlFileConverter.java
+++ b/src/main/java/edu/iris/dmc/station/converter/SeedToXmlFileConverter.java
@@ -11,6 +11,12 @@ import java.util.Map;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 import edu.iris.dmc.IrisUtil;
 import edu.iris.dmc.fdsn.station.model.FDSNStationXML;
@@ -68,12 +74,22 @@ public class SeedToXmlFileConverter implements MetadataFileFormatConverter<File>
 		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 		marshaller.marshal(document, file);
 	}
+	
+    public void marshal(FDSNStationXML document, OutputStream stream) throws IOException, JAXBException {  
+	    try {
+    	JAXBContext jaxbContext = JAXBContext.newInstance(edu.iris.dmc.fdsn.station.model.ObjectFactory.class);
+	    Marshaller marshaller = jaxbContext.createMarshaller();
+	    marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+	    DOMResult domResult = new DOMResult();
+	    marshaller.marshal(document, domResult);
 
-	public void marshal(FDSNStationXML document, OutputStream stream) throws IOException, JAXBException {
-		JAXBContext jaxbContext = JAXBContext.newInstance(edu.iris.dmc.fdsn.station.model.ObjectFactory.class);
-		Marshaller marshaller = jaxbContext.createMarshaller();
-		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-		marshaller.marshal(document, stream);
-	}
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+        transformer.transform(new DOMSource(domResult.getNode()), new StreamResult(stream));
+	     }catch(Exception e) {
+	    	e.printStackTrace();
+	     }
+     }
 
 }

--- a/src/main/java/edu/iris/dmc/station/converter/XmlToXmlFileConverter.java
+++ b/src/main/java/edu/iris/dmc/station/converter/XmlToXmlFileConverter.java
@@ -111,9 +111,7 @@ public class XmlToXmlFileConverter implements MetadataFileFormatConverter<File> 
 				for (Station station : network.getStations()) {
 					if (station.getChannels() != null) {
 						for (Channel channel : station.getChannels()) {
-						    if(channel.getStorageformat()!=null) {
-							    channel.setStorageFormat(null);
-						    }
+							channel.getAny().clear();
 							 if (channel.getResponse() != null) {
 									List<ResponseStage> stages = channel.getResponse().getStage();
 									if (stages != null) {

--- a/src/main/java/edu/iris/dmc/station/converter/XmlToXmlFileConverter.java
+++ b/src/main/java/edu/iris/dmc/station/converter/XmlToXmlFileConverter.java
@@ -1,0 +1,178 @@
+package edu.iris.dmc.station.converter;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Result;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import edu.iris.dmc.IrisUtil;
+import edu.iris.dmc.fdsn.station.model.Channel;
+import edu.iris.dmc.fdsn.station.model.Comment;
+import edu.iris.dmc.fdsn.station.model.Equipment;
+import edu.iris.dmc.fdsn.station.model.FDSNStationXML;
+import edu.iris.dmc.fdsn.station.model.Network;
+import edu.iris.dmc.fdsn.station.model.Polynomial;
+import edu.iris.dmc.fdsn.station.model.ResponseStage;
+import edu.iris.dmc.fdsn.station.model.Station;
+import edu.iris.dmc.io.SeedFormatter;
+import edu.iris.dmc.seed.BTime;
+import edu.iris.dmc.seed.Blockette;
+import edu.iris.dmc.seed.DictionaryIndex;
+import edu.iris.dmc.seed.SeedException;
+import edu.iris.dmc.seed.Volume;
+import edu.iris.dmc.seed.blockette.util.BlocketteItrator;
+import edu.iris.dmc.seed.control.dictionary.B030;
+import edu.iris.dmc.seed.control.dictionary.B031;
+import edu.iris.dmc.seed.control.dictionary.B033;
+import edu.iris.dmc.seed.control.dictionary.B034;
+import edu.iris.dmc.seed.control.index.B010;
+import edu.iris.dmc.seed.control.index.B011;
+import edu.iris.dmc.seed.control.station.B050;
+import edu.iris.dmc.seed.control.station.B051;
+import edu.iris.dmc.seed.control.station.B052;
+import edu.iris.dmc.seed.control.station.B053;
+import edu.iris.dmc.seed.control.station.B054;
+import edu.iris.dmc.seed.control.station.B057;
+import edu.iris.dmc.seed.control.station.B058;
+import edu.iris.dmc.seed.control.station.B059;
+import edu.iris.dmc.seed.control.station.B061;
+import edu.iris.dmc.seed.control.station.B062;
+import edu.iris.dmc.seed.director.BlocketteDirector;
+import edu.iris.dmc.seed.io.BlocketteOutputStream;
+import edu.iris.dmc.seed.io.RecordInputStream;
+import edu.iris.dmc.seed.io.SeedBufferedOutputStream;
+import edu.iris.dmc.seed.writer.SeedFileWriter;
+import edu.iris.dmc.station.ChannelCommentToBlocketteMapper;
+import edu.iris.dmc.station.FileConverterException;
+import edu.iris.dmc.station.mapper.ChannelBlocketteMapper;
+import edu.iris.dmc.station.mapper.CoefficientsMapper;
+import edu.iris.dmc.station.mapper.DecimationMapper;
+import edu.iris.dmc.station.mapper.FirToBlocketteMapper;
+import edu.iris.dmc.station.mapper.InstrumentSensitivityToBlocketteMapper;
+import edu.iris.dmc.station.mapper.MetadataConverterException;
+import edu.iris.dmc.station.mapper.PolesZerosMapper;
+import edu.iris.dmc.station.mapper.PolynomialMapper;
+import edu.iris.dmc.station.mapper.SensitivityToBlocketteMapper;
+import edu.iris.dmc.station.mapper.StageGainToBlocketteMapper;
+import edu.iris.dmc.station.mapper.StationBlocketteMapper;
+import edu.iris.dmc.station.mapper.StationCommentToBlocketteMapper;
+import edu.iris.dmc.station.mapper.UnitsMapper;
+import edu.iris.dmc.station.util.StationIterator;
+
+public class XmlToXmlFileConverter implements MetadataFileFormatConverter<File> {
+	private final Logger logger = Logger.getLogger(XmlToXmlFileConverter.class.getName());
+	private static XmlToXmlFileConverter INSTANCE = new XmlToXmlFileConverter();
+
+	public static MetadataFileFormatConverter<File> getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public void convert(File source, File target) throws IOException {
+		this.convert(source, target, null);
+	}
+
+	@Override
+	public void convert(File source, File target, Map<String, String> args) throws IOException {
+		// Volume.build must be in this convert method so b10 can be updated by user
+		// input
+		try (FileInputStream fileInputStream = new FileInputStream(source);
+				OutputStream fileOutputStream = new FileOutputStream(target)) {
+			    convert(fileInputStream, fileOutputStream, args);
+		}catch (Exception e) {
+			e.printStackTrace();
+		}
+    }
+
+	public void convert(InputStream inputStream, OutputStream outputStream, Map<String, String> args) throws FileConverterException, IOException {
+		try {
+			FDSNStationXML document = IrisUtil.readXml(inputStream);
+			document.setSchemaVersion(BigDecimal.valueOf(1.1));
+			for (Network network : document.getNetwork()) {
+				for (Station station : network.getStations()) {
+					if (station.getChannels() != null) {
+						for (Channel channel : station.getChannels()) {
+						    if(channel.getStorageformat()!=null) {
+							    channel.setStorageFormat(null);
+						    }
+							 if (channel.getResponse() != null) {
+									List<ResponseStage> stages = channel.getResponse().getStage();
+									if (stages != null) {
+										for (ResponseStage stage : stages) {
+											if (stage.getStageGain() != null) {
+												if(stage.getPolynomial() != null) {
+													if(stage.getStageGain().getValue()!=1) {
+														throw new MetadataConverterException(
+														"Blockette 58 in Network " +network.getCode() +" Station " + station.getCode() 
+														+ " Channel " + channel.getCode() + " stage "+ stage.getNumber()+" is non-unity. "
+														+ "This stage must be manually fixed before the file can be converted.");
+													}else {		
+													    stage.setStageGain(null);
+													    }
+													}
+										         }
+							                  }
+							 
+						                    }
+							             }
+					                  }
+
+
+				           }
+			          }
+		         }
+
+	marshal(document, outputStream);
+	
+		} catch (JAXBException | MetadataConverterException  e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+
+	}
+
+	
+	
+    public void marshal(FDSNStationXML document, File file) throws IOException, JAXBException {
+	    JAXBContext jaxbContext = JAXBContext.newInstance(edu.iris.dmc.fdsn.station.model.ObjectFactory.class);
+	    Marshaller marshaller = jaxbContext.createMarshaller();
+	    marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+	    marshaller.marshal(document, file);
+   }
+
+    public void marshal(FDSNStationXML document, OutputStream stream) throws IOException, JAXBException {  
+	    try {
+    	JAXBContext jaxbContext = JAXBContext.newInstance(edu.iris.dmc.fdsn.station.model.ObjectFactory.class);
+	    Marshaller marshaller = jaxbContext.createMarshaller();
+	    marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+	    DOMResult domResult = new DOMResult();
+	    marshaller.marshal(document, domResult);
+
+       Transformer transformer = TransformerFactory.newInstance().newTransformer();
+       transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+       transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+       transformer.transform(new DOMSource(domResult.getNode()), new StreamResult(stream));
+	    }catch(Exception e) {
+	    	e.printStackTrace();
+	    }
+    }
+}

--- a/src/test/java/edu/iris/dmc/station/converter/XmlToXmlFileConverterTest.java
+++ b/src/test/java/edu/iris/dmc/station/converter/XmlToXmlFileConverterTest.java
@@ -1,0 +1,102 @@
+package edu.iris.dmc.station.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import edu.iris.dmc.IrisUtil;
+import edu.iris.dmc.fdsn.station.model.Channel;
+import edu.iris.dmc.fdsn.station.model.FDSNStationXML;
+import edu.iris.dmc.fdsn.station.model.Network;
+import edu.iris.dmc.fdsn.station.model.ResponseStage;
+import edu.iris.dmc.fdsn.station.model.Station;
+import edu.iris.dmc.seed.Volume;
+import edu.iris.dmc.seed.control.dictionary.B031;
+import edu.iris.dmc.seed.control.dictionary.B033;
+import edu.iris.dmc.seed.control.station.B050;
+import edu.iris.dmc.seed.control.station.B051;
+import edu.iris.dmc.seed.control.station.B059;
+import edu.iris.dmc.seed.control.station.ResponseBlockette;
+import edu.iris.dmc.seed.control.station.Stage;
+import edu.iris.dmc.station.converter.XmlToSeedFileConverter;
+import edu.iris.dmc.station.mapper.MetadataConverterException;
+
+public class XmlToXmlFileConverterTest {
+
+
+	
+	@Test
+	public void EreaseStorageFormat() throws Exception {
+
+		File xml = new File(XmlToXmlFileConverterTest.class.getClassLoader().getResource("StorageFormatTest.xml").getFile());
+		FDSNStationXML documentOG = IrisUtil.readXml(xml);
+		assertTrue((documentOG.getSchemaVersion().doubleValue()==1.0));
+		for (Network network : documentOG.getNetwork()) {
+			for (Station station : network.getStations()) {
+				if (station.getChannels() != null) {
+					for (Channel channel : station.getChannels()) {
+						 if(channel.getStorageformat()!=null) {
+							assertTrue(channel.getStorageformat().contains("DOES WORK"));
+						 }
+					}
+				}
+			}
+		}
+		File convertedXML = new File("convertedxml");
+		XmlToXmlFileConverter.getInstance().convert(xml, convertedXML);
+		FDSNStationXML document = IrisUtil.readXml(convertedXML);		
+		assertTrue((document.getSchemaVersion().doubleValue()==1.1));		
+		for (Network network : document.getNetwork()) {
+			for (Station station : network.getStations()) {
+				if (station.getChannels() != null) {
+					for (Channel channel : station.getChannels()) {
+						assertTrue((channel.getStorageformat()==null)); 
+					}
+				}
+			}
+		}
+
+		
+
+
+	}
+	
+	@Test
+	public void B62B58Format() throws Exception {
+
+		File xml = new File(XmlToXmlFileConverterTest.class.getClassLoader().getResource("B62B58Unity.xml").getFile());
+		FDSNStationXML documentOG = IrisUtil.readXml(xml);
+		assertTrue((documentOG.getSchemaVersion().doubleValue()==1.0));
+		Network network = documentOG.getNetwork().get(0);
+		Station station = network.getStations().get(0); 
+		Channel channel = station.getChannels().get(0); 
+		ResponseStage stage = channel.getResponse().getStage().get(0);
+		assertTrue(stage.getStageGain() != null);
+		assertTrue(stage.getPolynomial() != null);
+					 
+		File convertedXML = new File("convertedxml");
+		XmlToXmlFileConverter.getInstance().convert(xml, convertedXML);
+		FDSNStationXML document = IrisUtil.readXml(convertedXML);		
+		assertTrue((document.getSchemaVersion().doubleValue()==1.1));		
+		Network network2 = document.getNetwork().get(0);
+		Station station2 = network2.getStations().get(0); 
+		Channel channel2 = station2.getChannels().get(0); 
+		ResponseStage stage2 = channel2.getResponse().getStage().get(0);
+		assertTrue(stage2.getStageGain() == null);
+		assertTrue(stage2.getPolynomial() != null);
+
+		
+
+
+	}
+	
+	
+}

--- a/src/test/java/edu/iris/dmc/station/converter/XmlToXmlFileConverterTest.java
+++ b/src/test/java/edu/iris/dmc/station/converter/XmlToXmlFileConverterTest.java
@@ -34,7 +34,7 @@ public class XmlToXmlFileConverterTest {
 
 	
 	@Test
-	public void EreaseStorageFormat() throws Exception {
+	public void ereaseStorageFormat() throws Exception {
 
 		File xml = new File(XmlToXmlFileConverterTest.class.getClassLoader().getResource("StorageFormatTest.xml").getFile());
 		FDSNStationXML documentOG = IrisUtil.readXml(xml);
@@ -42,9 +42,13 @@ public class XmlToXmlFileConverterTest {
 		for (Network network : documentOG.getNetwork()) {
 			for (Station station : network.getStations()) {
 				if (station.getChannels() != null) {
-					for (Channel channel : station.getChannels()) {
-						 if(channel.getStorageformat()!=null) {
-							assertTrue(channel.getStorageformat().contains("DOES WORK"));
+					for (Channel channel : station.getChannels()) {				 
+						if(channel.getAny()!=null) {
+							 System.out.println(channel.getAny().size());
+							 assertTrue(channel.getAny().size()==1);
+							 for(Object element : channel.getAny()) {
+								assertTrue(element.toString().contains("StorageFormat"));
+							 }
 						 }
 					}
 				}
@@ -58,15 +62,14 @@ public class XmlToXmlFileConverterTest {
 			for (Station station : network.getStations()) {
 				if (station.getChannels() != null) {
 					for (Channel channel : station.getChannels()) {
-						assertTrue((channel.getStorageformat()==null)); 
-					}
+						if(channel.getAny()!=null) {
+							 assertTrue(channel.getAny().size()==0);
+						 }
 				}
 			}
+		 }
+
 		}
-
-		
-
-
 	}
 	
 	@Test

--- a/src/test/resources/B62B58NonUnity.xml
+++ b/src/test/resources/B62B58NonUnity.xml
@@ -57,13 +57,6 @@
               <Coefficient number="0">0.0</Coefficient>
               <Coefficient number="1">0.1</Coefficient>
           </Polynomial>
-          <Decimation>
-               <InputSampleRate>40.0</InputSampleRate>
-               <Factor>1</Factor>
-               <Offset>0</Offset>
-               <Delay>0.5</Delay>
-               <Correction>0.5</Correction>
-             </Decimation>
              <StageGain>
                <Value>2.0</Value>
                <Frequency>0.0</Frequency>

--- a/src/test/resources/B62B58Unity.xml
+++ b/src/test/resources/B62B58Unity.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" ?>
+<FDSNStationXML schemaVersion="1.0" xmlns="http://www.fdsn.org/xml/station/1" xmlns:iris="http://www.fdsn.org/xml/station/1/iris" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.fdsn.org/xml/station/1 http://www.fdsn.org/xml/station/fdsn-station-1.1.xsd">
+  <Source>ASL</Source>
+  <Sender>ASL</Sender>
+  <Module>ASL WEB SERVICE: fdsnws-station | version: 0.0.0</Module>
+  <ModuleURI>file</ModuleURI>
+  <Created>2020-03-19T22:06:46.874085</Created>
+  <Network code="US" startDate="1991-03-28T00:00:00.000000">
+    <TotalNumberStations>74</TotalNumberStations>
+    <SelectedNumberStations>1</SelectedNumberStations>
+    <Station code="CBKS" startDate="1994-09-12T00:00:00.000000">
+      <Description>ANSS-NEIC</Description>
+      <Latitude>38.814</Latitude>
+      <Longitude>-99.7374</Longitude>
+      <Elevation>677.0</Elevation>
+      <Site>
+        <Name>Cedar Bluff, Kansas, USA</Name>
+      </Site>
+      <CreationDate>1994-09-12T00:00:00.000000</CreationDate>
+      <TotalNumberChannels>72</TotalNumberChannels>
+      <SelectedNumberChannels>72</SelectedNumberChannels>
+      <Channel code="VMU" locationCode="00" startDate="2016-05-02T20:45:00.000000">
+        <Latitude>38.814</Latitude>
+        <Longitude>-99.7374</Longitude>
+        <Elevation>677.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth>0.0</Azimuth>
+        <Dip>0.0</Dip>
+        <Type>CONTINUOUS</Type>
+        <Type>HEALTH</Type>
+        <SampleRate>0.1</SampleRate>
+        <ClockDrift>0.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>V</Name>
+          <Description>Volts</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Description>STS2-I=10443=Gen=Q330SR=1266</Description>
+        </Sensor>
+        <Response>
+          <Stage number="1">
+            <Polynomial>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>count</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <ApproximationType>MACLAURIN</ApproximationType>
+              <FrequencyLowerBound>0.0</FrequencyLowerBound>
+              <FrequencyUpperBound>0.05</FrequencyUpperBound>
+              <ApproximationLowerBound>-10.0</ApproximationLowerBound>
+              <ApproximationUpperBound>10.0</ApproximationUpperBound>
+              <MaximumError>0.0</MaximumError>
+              <Coefficient number="0">0.0</Coefficient>
+              <Coefficient number="1">0.1</Coefficient>
+          </Polynomial>
+          <Decimation>
+               <InputSampleRate>40.0</InputSampleRate>
+               <Factor>1</Factor>
+               <Offset>0</Offset>
+               <Delay>0.5</Delay>
+               <Correction>0.5</Correction>
+             </Decimation>
+             <StageGain>
+               <Value>1.0</Value>
+               <Frequency>0.0</Frequency>
+             </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+  </Network>
+</FDSNStationXML>

--- a/src/test/resources/StorageFormatTest.xml
+++ b/src/test/resources/StorageFormatTest.xml
@@ -1,0 +1,625 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1" schemaVersion="1.0" xsi:schemaLocation="http://www.fdsn.org/xml/station/1 http://www.fdsn.org/xml/station/fdsn-station-1.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:iris="http://www.fdsn.org/xml/station/1/iris">
+ <Source>IRIS-DMC</Source>
+ <Sender>IRIS-DMC</Sender>
+ <Module>IRIS WEB SERVICE: fdsnws-station | version: 1.1.33</Module>
+ <ModuleURI>http://service.iris.edu/fdsnws/station/1/query?net=QI&amp;sta=VPASS&amp;cha=BDF&amp;starttime=2018-08-06T00:00:01&amp;level=response&amp;format=xml&amp;includecomments=true&amp;nodata=404</ModuleURI>
+ <Created>2018-08-06T20:17:16</Created>
+ <Network code="XX" startDate="2014-01-01T00:00:00" endDate="2500-12-31T23:59:59" restrictedStatus="open">
+  <Description>[IRIS DMC] Station XML Validator Passing Test File</Description>
+  <TotalNumberStations>1</TotalNumberStations>
+  <SelectedNumberStations>1</SelectedNumberStations>
+  <Station code="TPASS" startDate="2014-01-01T00:00:00" endDate="2500-12-31T23:59:59" restrictedStatus="open" iris:alternateNetworkCodes="_FDSN,.UNRESTRICTED">
+   <Latitude>47.66157</Latitude>
+   <Longitude>-122.31332</Longitude>
+   <Elevation>225.879999</Elevation>
+   <Site>
+    <Name>Synthetic Test File, IRIS DMC, USA, 218 2018, Tim Ronan</Name>
+   </Site>
+   <CreationDate>2018-08-06T00:00:00</CreationDate>
+   <TotalNumberChannels>1</TotalNumberChannels>
+   <SelectedNumberChannels>1</SelectedNumberChannels>
+   <Channel code="BDF" endDate="2500-12-31T23:59:59" locationCode="00" restrictedStatus="open" startDate="2018-08-06T00:00:00">
+    <Latitude>47.66157</Latitude>
+    <Longitude>-122.31332</Longitude>
+    <Elevation>225.879999</Elevation>
+    <Depth>0</Depth>
+    <Azimuth>359</Azimuth>
+    <Dip>0</Dip>
+    <Type>CONTINUOUS</Type>
+    <Type>GEOPHYSICAL</Type>
+    <SampleRate>2E01</SampleRate>
+    <StorageFormat>DOES WORK</StorageFormat>
+    <ClockDrift>0E00</ClockDrift>
+    <CalibrationUnits>
+     <Name>V</Name>
+     <Description>Volts</Description>
+    </CalibrationUnits>
+    <Sensor>
+     <Description>GEM (Infrasound), 0.2-50 Hz, 0.4 V/Pa-null</Description>
+    </Sensor>
+    <Response>
+     <InstrumentSensitivity>
+      <Value>2.44648E5</Value>
+      <Frequency>1E0</Frequency>
+      <InputUnits>
+       <Name>PA</Name>
+       <Description>No Abbreviation Referenced</Description>
+      </InputUnits>
+      <OutputUnits>
+       <Name>COUNTS</Name>
+       <Description>Digital Counts</Description>
+      </OutputUnits>
+     </InstrumentSensitivity>
+     <Stage number="1">
+      <PolesZeros>
+       <InputUnits>
+        <Name>PA</Name>
+        <Description>No Abbreviation Referenced</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>V</Name>
+        <Description>Volts</Description>
+       </OutputUnits>
+       <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+       <NormalizationFactor>314.1</NormalizationFactor>
+       <NormalizationFrequency>1.00000</NormalizationFrequency>
+       <Zero number="0">
+        <Real plusError="1.00000">0.00000</Real>
+        <Imaginary minusError="0.00000" >0.00000</Imaginary>
+       </Zero>
+       <Zero number="1">
+        <Real minusError="0.00000" plusError="0.00000">0.00000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Zero>
+       <Zero number="2">
+        <Real minusError="0.00000" plusError="0.00000">-0.170000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Zero>
+       <Pole number="0">
+        <Real minusError="0.00000" plusError="0.00000">0.00000</Real>
+        <Imaginary minusError="-21.00000" plusError="0.00000">0.00000</Imaginary>
+       </Pole>
+       <Pole number="1">
+        <Real>-314.000</Real>
+        <Imaginary>0.00000</Imaginary>
+       </Pole>
+       <Pole number="2">
+        <Real minusError="0.00000" plusError="0.00000">-0.188000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Pole>
+       <Pole number="3">
+        <Real minusError="0.00000" plusError="0.00000">-0.0440000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Pole>
+      </PolesZeros>
+      <StageGain>
+       <Value>0.4</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="2">
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="3">
+      <Coefficients>
+       <InputUnits>
+        <Name>V</Name>
+        <Description>Volts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">1.00000</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>512000.0</InputSampleRate>
+       <Factor>1</Factor>
+       <Offset>0</Offset>
+       <Delay>0.0</Delay>
+       <Correction>0.0</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>611621.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="4">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000305176</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000152588</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000457764</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00106812</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00213623</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00384521</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00640869</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0100708</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0149536</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0210571</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0282593</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0363159</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0448608</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0534058</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0613403</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0679321</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0726318</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0750732</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0750732</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0726318</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0679321</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0613403</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0534058</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0448608</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0363159</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0282593</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0210571</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0149536</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0100708</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00640869</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00384521</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00213623</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00106812</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000457764</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000152588</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000305176</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>512000.0</InputSampleRate>
+       <Factor>8</Factor>
+       <Offset>0</Offset>
+       <Delay>3.418E-5</Delay>
+       <Correction>3.418E-5</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="5">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.156250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.156250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0312500</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>64000.0</InputSampleRate>
+       <Factor>2</Factor>
+       <Offset>0</Offset>
+       <Delay>3.9063E-5</Delay>
+       <Correction>3.9063E-5</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="6">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0156250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0937500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.234375</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.234375</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0937500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0156250</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>32000.0</InputSampleRate>
+       <Factor>2</Factor>
+       <Offset>0</Offset>
+       <Delay>9.375E-5</Delay>
+       <Correction>9.375E-5</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="7">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00160000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00640000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0160000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0320000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0560000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0832000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.108800</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.128000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.136000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.128000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.108800</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0832000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0560000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0320000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0160000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00640000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00160000</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>16000.0</InputSampleRate>
+       <Factor>5</Factor>
+       <Offset>0</Offset>
+       <Delay>5.0E-4</Delay>
+       <Correction>5.0E-4</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="8">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00160000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00640000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0160000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0320000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0560000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0832000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.108800</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.128000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.136000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.128000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.108800</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0832000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0560000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0320000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0160000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00640000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00160000</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>3200.0</InputSampleRate>
+       <Factor>5</Factor>
+       <Offset>0</Offset>
+       <Delay>0.0025</Delay>
+       <Correction>0.0025</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="9">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.156250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.156250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0312500</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>640.0</InputSampleRate>
+       <Factor>2</Factor>
+       <Offset>0</Offset>
+       <Delay>0.0039062</Delay>
+       <Correction>0.0039062</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="10">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0156250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0937500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.234375</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.234375</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0937500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0156250</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>320.0</InputSampleRate>
+       <Factor>2</Factor>
+       <Offset>0</Offset>
+       <Delay>0.009375</Delay>
+       <Correction>0.009375</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="11">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000142825</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000487602</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000981347</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000131000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00000934250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000371601</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00101838</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00172427</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00178938</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000497840</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00249391</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00662629</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00961284</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00850723</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00102035</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0127048</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0277493</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0356507</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0269602</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00484878</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0580113</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.122066</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.180265</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.214714</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.214714</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.180265</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.122066</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0580113</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00484878</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0269602</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0356507</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0277493</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0127048</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00102035</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00850723</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00961284</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00662629</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00249391</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000497840</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00178938</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00172427</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00101838</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000371601</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00000934250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000131000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000981347</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000487602</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000142825</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>160.0</InputSampleRate>
+       <Factor>4</Factor>
+       <Offset>0</Offset>
+       <Delay>0.14688</Delay>
+       <Correction>0.14688</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="12">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00000</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00000341752</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000178578</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000418767</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000474602</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00000163656</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000859675</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000110275</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000140070</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000980010</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000453905</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000143680</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000182139</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000701795</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000279563</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000484710</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000373328</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000285676</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000343437</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000562736</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000169962</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000842347</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000211212</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000994499</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000768220</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000911179</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00143478</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000471474</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00204921</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000372799</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00240642</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00158944</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00226673</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00301565</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00142968</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00436788</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000213523</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00525571</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00260752</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00524705</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00549470</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00394666</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00839709</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00109986</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0106478</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00331466</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0114571</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00900786</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0100128</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0153434</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00558380</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0213365</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00240468</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0256716</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0143909</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0266602</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0309250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0219005</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0536113</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00660299</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0892570</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0368818</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.186535</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.403778</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.403778</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.186535</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0368818</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0892570</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00660299</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0536113</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0219005</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0309250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0266602</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0143909</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0256716</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00240468</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0213365</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00558380</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0153434</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0100128</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00900786</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0114571</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00331466</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0106478</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00109986</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00839709</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00394666</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00549470</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00524705</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00260752</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00525571</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000213523</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00436788</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00142968</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00301565</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00226673</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00158944</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00240642</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000372799</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00204921</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000471474</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00143478</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000911179</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000768220</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000994499</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000211212</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000842347</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000169962</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000562736</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000343437</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000285676</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000373328</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000484710</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.000279563</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000701795</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000182139</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000143680</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000453905</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000980010</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000140070</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.000110275</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0000859675</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00000163656</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000474602</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000418767</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.0000178578</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">-0.00000341752</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.00000</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>40.0</InputSampleRate>
+       <Factor>2</Factor>
+       <Offset>0</Offset>
+       <Delay>1.5875</Delay>
+       <Correction>1.5875</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+    </Response>
+   </Channel>
+  </Station>
+ </Network>
+</FDSNStationXML>


### PR DESCRIPTION
Adds a flag, schema-update, that transforms stationxml from 1.0 to 1.1. 
Flag strips all schema extensions and StorageFormat Element from stationxml 1.1. 
Stages with Polynomial and StageGain are corrected or an output message is thrown. 
Test include XMLtoXMLFileConverterTest, eraseStorageFormat, and B62B58Format. 
 

